### PR TITLE
feat(tests): add parameter to test performance bottleneck

### DIFF
--- a/example/simple_many_tasks.nf
+++ b/example/simple_many_tasks.nf
@@ -1,3 +1,5 @@
+params.numberOfTasks = 5000
+
 process sleep {
   input:
     val x
@@ -8,5 +10,5 @@ process sleep {
 }
 
 workflow {
-  channel.from(0..200) | sleep
+  channel.from(0..params.numberOfTasks) | sleep
 }


### PR DESCRIPTION
This PR adds a simple parameter to increase the number of tasks:
```
./nextflow  run  -with-weblog http://localhost:8000/run/onPaKKnFuzelhfV/ simple_many_tasks.nf --numberOfTasks 20000
```

